### PR TITLE
fix: remove recreating zap logger; change time field to latency

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -17,7 +17,6 @@ func ZapLogger(log *zap.Logger) echo.MiddlewareFunc {
 
 			err := next(c)
 			if err != nil {
-				log = log.With(zap.Error(err))
 				c.Error(err)
 			}
 
@@ -26,7 +25,7 @@ func ZapLogger(log *zap.Logger) echo.MiddlewareFunc {
 
 			fields := []zapcore.Field{
 				zap.String("remote_ip", c.RealIP()),
-				zap.String("time", time.Since(start).String()),
+				zap.String("latency", time.Since(start).String()),
 				zap.String("host", req.Host),
 				zap.String("request", fmt.Sprintf("%s %s", req.Method, req.RequestURI)),
 				zap.Int("status", res.Status),
@@ -43,9 +42,9 @@ func ZapLogger(log *zap.Logger) echo.MiddlewareFunc {
 			n := res.Status
 			switch {
 			case n >= 500:
-				log.Error("Server error", fields...)
+				log.With(zap.Error(err)).Error("Server error", fields...)
 			case n >= 400:
-				log.Warn("Client error", fields...)
+				log.With(zap.Error(err)).Warn("Client error", fields...)
 			case n >= 300:
 				log.Info("Redirection", fields...)
 			default:


### PR DESCRIPTION
I tried to use this middleware and just stress tested it with 1mln connections and it gave me only about 400 RPS, which is impossible.
I didn't profile the code, but it seems that assigning `log.With(zap.Error(err))` to `log` object makes it very slow. 

After the fix I got my 35000 RPS as before