### PR TITLE
feat: Introduce route Skipper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ export GO111MODULE=on
 dev-deps: ## Install Development dependencies
 	npm i -g conventional-changelog-cli commitizen
 
-dev: ## Setup the Development envrionment
+dev: ## Setup the Development environment
 	pre-commit install
 
 fmt: ## Formats the go code using gofmt

--- a/logger_test.go
+++ b/logger_test.go
@@ -3,6 +3,7 @@ package echozap
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/labstack/echo/v4"
@@ -37,4 +38,29 @@ func TestZapLogger(t *testing.T) {
 	assert.Equal(t, "GET /something", logFields["request"])
 	assert.NotNil(t, logFields["host"])
 	assert.NotNil(t, logFields["size"])
+}
+
+func TestZapLoggerWithConfig(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/something", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	h := func(c echo.Context) error {
+		return c.String(http.StatusOK, "")
+	}
+
+	obs, logs := observer.New(zap.DebugLevel)
+
+	logger := zap.New(obs)
+
+	err := ZapLoggerWithConfig(logger, ZapLoggerConfig{
+		Skipper: func(ctx echo.Context) bool {
+			return strings.Contains(ctx.Request().URL.Path, "/something")
+		},
+	})(h)(c)
+
+	assert.Nil(t, err)
+
+	assert.Equal(t, 0, logs.Len())
 }


### PR DESCRIPTION
Hello!

Thank you very much for providing this middleware to the community :) We have been actively using it in our company, but we noticed that for health probes it constantly produces logs that we are not interested in. This PR introduces a Skipper, so that someone can decide to exclude certain routes from getting logged when a request arrives.

I have added the related tests and in order to be backwards compatible with the previous version of the middleware, I have added a default configuration. 

